### PR TITLE
installation table matches NOIRLab page of links for MacOS

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -82,7 +82,8 @@ File                        Compiled on     Compatible With
 ==========================  =============== =========================
 gmmps-1.5.2_rh7_64.tgz      CentOS 7        Ubuntu 17/22
 gmmps-1.5.2_ub16_64.tgz     Ubuntu 16.04    Ubuntu 17/22
-gmmps-1.5.2_macos.tgz       macOS 10.13.6   macOS 10.14/14
+gmmps-1.5.2_macos.tgz       macOS 10.13.6   macOS 10.14 - 13.5
+gmmps-1.5.2_macos15.tgz     macOS 10.15     macOS 11 - 13.5
 ==========================  =============== =========================
 
 Untar the distribution file and then::


### PR DESCRIPTION
Addressing HelpDesk ticket [449](https://noirlab.atlassian.net/browse/EXTHD-449), I added a line to the table of pre-compiled versions of GMMPS for MacOS. The lines for MacOS should now be identical to the table on the NOIRLab page. 